### PR TITLE
fixed out of order imports

### DIFF
--- a/root.go
+++ b/root.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/cpuguy83/strongerrors"
 	"github.com/Azure/k8s-testrig/commands"
+	"github.com/cpuguy83/strongerrors"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Love the tool! I noticed that the imports on root.go were out of order. It's really minor but I decided to just run goimports on it